### PR TITLE
Added synchronisation of RTC clock with NTP server

### DIFF
--- a/.vscode/arduino.json
+++ b/.vscode/arduino.json
@@ -1,6 +1,7 @@
 {
     "board": "esp32:esp32:ttgo-t-watch",
     "configuration": "PSRAM=enabled,PartitionScheme=default,UploadSpeed=2000000,DebugLevel=none",
-    "port": "/dev/tty.SLAB_USBtoUART",
-    "sketch": "mario.ino"
+    "port": "COM7",
+    "sketch": "mario.ino",
+    "output": "../build"
 }

--- a/mario.ino
+++ b/mario.ino
@@ -1,5 +1,8 @@
 #include "config.h"
 #include "src/gui.h"
+#include <WiFi.h>
+#include "src/secret.h"
+#include "time.h"
 
 #define DEFAULT_SCREEN_TIMEOUT 10 * 1000
 
@@ -14,6 +17,22 @@ QueueHandle_t g_event_queue_handle = NULL;
 EventGroupHandle_t g_event_group = NULL;
 EventGroupHandle_t isr_group = NULL;
 bool lenergy = false;
+bool tryNTPtime = true;
+bool useNTPtime = false;
+
+// Wifi variables 
+// The credetials are stored in src/secret.h file that doesnt need to be synched with the repo. The followin format is used:
+// #define SSID "MY_SSID"
+// #define PASSWORD "MY_PASSWORD"
+// TODO: store this infos in a crypted way?
+const char* ssid       = "SSID";
+const char* password   = "PASSWORD";
+
+// NTP Settings : for more ionformations, https://lastminuteengineers.com/esp32-ntp-server-date-time-tutorial/
+const char* ntpServer = "pool.ntp.org"; // (for worlwide NTP server)
+// const char* ntpServer = "europe.pool.ntp.org";
+const long  gmtOffset_sec = 3600;
+const int   daylightOffset_sec = 3600;
 
 Gui *gui;
 
@@ -83,11 +102,52 @@ void low_energy()
         ttgo->bma->enableStepCountInterrupt();
     }
 }
+
+void synchRtc2Ntp()
+{
+    //connect to WiFi
+    Serial.printf("Connecting to %s ", ssid);
+    WiFi.begin(ssid, password);
+    while (WiFi.status() != WL_CONNECTED) 
+    {
+        delay(500);
+        Serial.print("."); 
+    }
+    Serial.printf("Connected to %s ", ssid);
+  
+    //init and get the time from NTP server
+    configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);
+    struct tm timeinfo;
+    if(!getLocalTime(&timeinfo))
+    {
+        Serial.println("Failed to obtain time");
+        return;
+    }
+    Serial.println(&timeinfo, "%A, %B %d %Y %H:%M:%S");
+    // RTC_Date updateRTC =(timeinfo.tm_year,timeinfo.tm_mon,timeinfo.tm_mday,timeinfo.tm_hour,timeinfo.tm_min,timeinfo.tm_sec);
+    // ttgo->rtc->setDateTime(updateRTC);
+    RTC_Date updateRTC ;
+    updateRTC.year = timeinfo.tm_year;
+    updateRTC.month = timeinfo.tm_mon;
+    updateRTC.day = timeinfo.tm_mday;
+    updateRTC.hour = timeinfo.tm_hour;
+    updateRTC.minute = timeinfo.tm_min;
+    updateRTC.second = timeinfo.tm_sec;
+    ttgo->rtc->setDateTime(updateRTC);
+    // ttgo->rtc->syncToRtc();
+    Serial.println("RTC time synched with NTP");
+    useNTPtime = true;
+
+    //disconnect WiFi as it's no longer needed
+    WiFi.disconnect(true);
+    WiFi.mode(WIFI_OFF);
+}
+
 void setup()
 {
     Serial.begin(115200);
     Serial.println("Woked-up!");
-    ttgo = TTGOClass::getWatch();
+    // ttgo = TTGOClass::getWatch();
 
     //initWakeupTriggers();
 
@@ -167,11 +227,23 @@ void setup()
 
     //Check if the RTC clock matches, if not, use compile time
     ttgo->rtc->check();
+    Serial.printf("RTC time: %s\n", ttgo->rtc->formatDateTime());
 
-    //Synchronize time to system time
-    ttgo->rtc->syncToSystem();
 
-    Serial.printf("%s\n", ttgo->rtc->formatDateTime());
+    if (tryNTPtime == false)
+    {
+        //Synchronize time to system time
+        ttgo->rtc->syncToSystem();
+
+        Serial.printf("System time: %s\n", ttgo->rtc->formatDateTime());
+        useNTPtime = false;
+    } else {
+
+        //Synchronize time to NTP
+
+        synchRtc2Ntp();
+    }
+    
     gui = new Gui();
     gui->setupGui();
 }
@@ -254,6 +326,7 @@ void loop()
             if (ttgo->power->isPEKShortPressIRQ())
             {
                 Serial.println("PEK Short press");
+                Serial.printf("Current time: %s\n", ttgo->rtc->formatDateTime());
                 ttgo->power->clearIRQ();
                 low_energy();
                 return;

--- a/mario.ino
+++ b/mario.ino
@@ -25,8 +25,8 @@ bool useNTPtime = false;
 // #define SSID "MY_SSID"
 // #define PASSWORD "MY_PASSWORD"
 // TODO: store this infos in a crypted way?
-const char* ssid       = "SSID";
-const char* password   = "PASSWORD";
+const char* ssid       = SSID;
+const char* password   = PASSWORD;
 
 // NTP Settings : for more ionformations, https://lastminuteengineers.com/esp32-ntp-server-date-time-tutorial/
 const char* ntpServer = "pool.ntp.org"; // (for worlwide NTP server)
@@ -106,14 +106,14 @@ void low_energy()
 void synchRtc2Ntp()
 {
     //connect to WiFi
-    Serial.printf("Connecting to %s ", ssid);
+    Serial.printf("Connecting to %s \n", ssid);
     WiFi.begin(ssid, password);
     while (WiFi.status() != WL_CONNECTED) 
     {
         delay(500);
         Serial.print("."); 
     }
-    Serial.printf("Connected to %s ", ssid);
+    Serial.printf("\nConnected to %s \n", ssid);
   
     //init and get the time from NTP server
     configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);


### PR DESCRIPTION
Hi,

Just added the NTP server sync features, you can select this option by setting the variable tryNTPtime to true and by adding a secret.h file in src folder whith the following informations in it:
#define SSID "YOUR_SSID"
#define PASSWORD "YOUR_PASSWORD".

It would be nice if we can maybe implement a button on the left higher cloud that would permit to trig a synchronization manually. Or even better, enter a second "settings GUI Menu" where I could scan all the wifis, select the good one and enter the password with a keyboard...I would inspire me from this repo: [https://github.com/sharandac/My-TTGO-Watch](url) , and in particular mode the code from this file: [https://github.com/sharandac/My-TTGO-Watch/blob/master/src/hardware/wifictl.cpp](url) .

Give it a look, and let me know your toughs.

Best Regards,

Attilio